### PR TITLE
Unpermitted parametersの解消

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_filter :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:faculty_id])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:department_id])
+  end
+
 end


### PR DESCRIPTION
## やったこと
deviseの初期設定では、faculty_idとdepartment_idは弾かれてしまい、新規登録ができないバグ？を解消。
これで新規登録できます。

## やってないこと
学部学科は今はテキストではなんでも入れれるようになっているので、セレクトボックスに移行する。
